### PR TITLE
Allow multiple connections

### DIFF
--- a/config/db.yml-dist.example
+++ b/config/db.yml-dist.example
@@ -1,6 +1,15 @@
-database: <%db.name%>
-host: <%db.host%>
-user: <%db.user%>
-password: <%db.password%>
-port: <%db.port%>
-charset: <%db.charset%>
+default:
+    database: <%db.name%>
+    host: <%db.host%>
+    user: <%db.user%>
+    password: <%db.password%>
+    port: <%db.port%>
+    charset: <%db.charset%>
+
+otherDatabaseConnection:
+    database: <%db.other.name%>
+    host: <%db.other.host%>
+    user: <%db.other.user%>
+    password: <%db.other.password%>
+    port: <%db.other.port%>
+    charset: <%db.other.charset%>

--- a/src/DBAL.php
+++ b/src/DBAL.php
@@ -6,29 +6,56 @@ use Silex\ServiceProviderInterface;
 use Puzzle\Configuration;
 use Silex\Application;
 use Silex\Provider\DoctrineServiceProvider;
+use Puzzle\PrefixedConfiguration;
 
 class DBAL implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
         $this->validatePuzzleConfiguration($app);
+        $this->registerDatabases($app);
+    }
+
+    private function registerDatabases(Application $app)
+    {
+        $options = array();
+        $configuration = $app['configuration'];
+
+        $databases = array_keys($configuration->readRequired('db'));
+        foreach($databases as $database)
+        {
+            $options[$database] = $this->registerDatabase($app, $configuration, $database);
+        }
 
         $app->register(new DoctrineServiceProvider(), array(
-            'db.options' => array(
-                'driver'   => 'pdo_mysql',
-                'dbname'   => $app['configuration']->readRequired('db/database'),
-                'host'     => $app['configuration']->readRequired('db/host'),
-                'user'     => $app['configuration']->readRequired('db/user'),
-                'password' => $app['configuration']->readRequired('db/password'),
-                'port'     => $app['configuration']->read('db/port', 3306),
-                'charset'  => $app['configuration']->read('db/charset', 'utf8'),
-            )
+            'dbs.options' => $options
         ));
+    }
+
+    private function registerDatabase(Application $app, Configuration $configuration, $database)
+    {
+        $configuration = new PrefixedConfiguration($configuration, "db/$database");
+
+        $options = array(
+            'driver'   => 'pdo_mysql',
+            'dbname'   => $configuration->readRequired('database'),
+            'host'     => $configuration->readRequired('host'),
+            'user'     => $configuration->readRequired('user'),
+            'password' => $configuration->readRequired('password'),
+            'port'     => $configuration->read('port', 3306),
+            'charset'  => $configuration->read('charset', 'utf8'),
+        );
+
+        // Declare helper
+        $app["db.$database"] = $app->share(function () use ($app, $database) {
+            return $app['dbs'][$database];
+        });
+
+        return $options;
     }
 
     public function boot(Application $app)
     {
-        ;
     }
 
     private function validatePuzzleConfiguration(Application $app)

--- a/src/DBAL.php
+++ b/src/DBAL.php
@@ -35,7 +35,7 @@ class DBAL implements ServiceProviderInterface
     {
         if(! isset($app['configuration']) || ! $app['configuration'] instanceof Configuration)
         {
-            throw new \LogicException('AsseticProvider requires an instance of puzzle/configuration for the key configuration to be defined.');
+            throw new \LogicException(__CLASS__ . ' requires an instance of puzzle/configuration (as key "configuration")');
         }
     }
 }


### PR DESCRIPTION
Note that default database is still accessible by `$app['db']` (and also by `$app['db.default']` and `$app['dbs']['default']`

Others databases are accessible by`$app['db.mydbname']` or `$app['dbs']['mydbname']`
